### PR TITLE
Fixed variable expansion in function call with keyword argument. 

### DIFF
--- a/lib/Text/Sass.pm
+++ b/lib/Text/Sass.pm
@@ -24,6 +24,17 @@ our $VERSION = q[1.0.0];
 our $DEBUG   = 0;
 Readonly::Scalar our $DEBUG_SEPARATOR => 30;
 
+{
+  package TOKEN;
+  use Readonly;
+
+  # TODO: Use token patterns from original sass and use them consistently
+
+  Readonly our $ESCAPE => qr/\\./;
+  Readonly our $NMCHAR => qr/[^\s:\\]|$ESCAPE/;
+  Readonly our $IDENT  => qr/(?:$NMCHAR)+/;
+}
+
 sub new {
   my ($class, $ref) = @_;
 
@@ -626,8 +637,11 @@ sub _expr {
   my ($self, $stash, $symbols, $expr) = @_;
   my $vars = $symbols->{variables} || {};
 
-  $expr =~ s/\!(\S+)/{$vars->{$1}||"\!$1"}/smxeg;
-  $expr =~ s/\$(\S+)/{$vars->{$1}||"\$$1"}/smxeg;
+  #########
+  # Do variable expansion
+  #
+  $expr =~ s/\!($TOKEN::IDENT)/{$vars->{$1}||"\!$1"}/smxeg;
+  $expr =~ s/\$($TOKEN::IDENT)/{$vars->{$1}||"\$$1"}/smxeg;
 
   {
     # Functions

--- a/t/30-variables.t
+++ b/t/30-variables.t
@@ -9,7 +9,7 @@
 use strict;
 use warnings;
 use Text::Sass;
-use Test::More tests => 1;
+use Test::More tests => 2;
 
 {
   my $sass_str = <<"EOT";
@@ -40,5 +40,24 @@ EOT
 EOT
 
   my $sass = Text::Sass->new();
-  is($sass->sass2css($sass_str), $css_str, 'sass2css');
+  is($sass->sass2css($sass_str), $css_str, 'sass variables');
 }
+
+{
+  my $sass_str = <<'EOT';
+!blue\: = #3bbfce
+
+.content_navigation
+  border-color = !blue\:
+EOT
+
+  my $css_str = <<"EOT";
+.content_navigation {
+  border-color: #3bbfce;
+}
+EOT
+
+  my $sass = Text::Sass->new();
+  is($sass->sass2css($sass_str), $css_str, 'sass variable with escaped colon in name');
+}
+

--- a/t/61-keyword-arguments.t
+++ b/t/61-keyword-arguments.t
@@ -1,0 +1,36 @@
+# -*- mode: cperl; tab-width: 8; indent-tabs-mode: nil; basic-offset: 2 -*-
+# vim:ts=8:sw=2:et:sta:sts=2
+#########
+
+use strict;
+use warnings;
+use Text::Sass;
+use Test::More tests => 2;
+
+# TODO: Check whole CSS when keyword arguments are implemented
+
+{
+  my $scss = <<'EOT';
+$s: bla;
+li {
+  content: quote($string: $s);
+}
+EOT
+
+  my $ts = Text::Sass->new();
+  like($ts->scss2css($scss), qr/\bbla\b/,
+    "variable substitution in keyword argument");
+}
+
+{
+  my $scss = <<'EOT';
+$s: bla;
+li {
+  content: quote($string:$s);
+}
+EOT
+
+  my $ts = Text::Sass->new();
+  like($ts->scss2css($scss), qr/\bbla\b/,
+    "variable substitution in keyword argument after missing space");
+}

--- a/t/62-nested-calls.t
+++ b/t/62-nested-calls.t
@@ -1,0 +1,38 @@
+# -*- mode: cperl; tab-width: 8; indent-tabs-mode: nil; basic-offset: 2 -*-
+# vim:ts=8:sw=2:et:sta:sts=2
+#########
+
+use strict;
+use warnings;
+use Text::Sass;
+use Test::More tests => 2;
+
+{
+  my $scss = <<'EOT';
+li {
+  background: darken(darken(#3bbfce, 9%), 1%);
+}
+EOT
+
+  SKIP: {
+    skip "Nested function calls don't work", 1;
+    my $ts = Text::Sass->new();
+    like($ts->scss2css($scss), qr/\Qbackground: #299daa;\E/,
+      "nested function calls");
+  }
+}
+
+{
+  my $scss = <<'EOT';
+$blue: #3bbfce;
+$darkBlue: darken($blue, 9%);
+li {
+  background: darken($darkBlue, 1%);
+}
+EOT
+
+  my $ts = Text::Sass->new();
+  like($ts->scss2css($scss), qr/\Qbackground: #299daa;\E/,
+    "nested function calls created via intermediate variable");
+}
+


### PR DESCRIPTION
This patch fixes variable expansion when '$' immediately follows ':',
preceded by another variable, like $foo:$bar. This pattern can occur in
function call with keyword argument which is not supported by Text::Sass,
but has incomplete implementation in my custom extension.

Variable substitution code used too greedy patter (\S+) for matching
identifiers, e.g. "$foo:$bar" code was interpreted as having "foo:$bar"
variable.

However, precise matching of variables uncovers submarine bug with nested
function calls which are partially working just beacuse of over-greedy
pattern matching. See test case t/62-nested-calls.t

So for now I just forbid variable names from having unescaped colon.
